### PR TITLE
fix declaration issue

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,3 +83,5 @@ networks:
 
 volumes:
   mysql-data:
+  portainer-data:
+  redis-data:


### PR DESCRIPTION
# Pull Request
### Added declaration of the used volumes
## Description

deployment was complaining missing declaration of two volumes: redis-data and portainer-data.
added these in the volumes section where mysql-data is

---

## Type of Change

What type of change does this pull request introduce? (Check all that apply)

- [* ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

---
